### PR TITLE
Renaming boilerplate with gitignore-cli

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,20 +1,20 @@
 #!/usr/bin/env node
 'use strict';
 var meow = require('meow');
-var <%= camelModuleName %> = require('./');
+var gitignoreCli = require('./');
 
 var cli = meow([
 	'Usage',
-	'  $ <%= moduleName %> [input]',
+	'  $ gitignore-cli [input]',
 	'',
 	'Options',
 	'  --foo  Lorem ipsum. [Default: false]',
 	'',
 	'Examples',
-	'  $ <%= moduleName %>',
+	'  $ gitignore-cli',
 	'  unicorns & rainbows',
-	'  $ <%= moduleName %> ponies',
+	'  $ gitignore-cli ponies',
 	'  ponies & rainbows'
 ]);
 
-console.log(<%= camelModuleName %>(cli.input[0] || 'unicorns'));
+console.log(gitignoreCli(cli.input[0] || 'unicorns'));

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "<%= moduleName %>",
+  "name": "gitignore-cli",
   "version": "0.0.0",
   "description": "",
   "license": "MIT",
-  "repository": "<%= githubUsername %>/<%= moduleName %>",
+  "repository": "kvasir/gitignore-cli",
   "author": {
-    "name": "<%= name %>",
-    "email": "<%= email %>",
-    "url": "<%= website %>"
+    "name": "Kvasir",
+    "email": "",
+    "url": ""
   },
   "bin": "cli.js",
   "engines": {

--- a/readme.md
+++ b/readme.md
@@ -1,28 +1,24 @@
-# <%= moduleName %> [![Build Status](https://travis-ci.org/<%= githubUsername %>/<%= moduleName %>.svg?branch=master)](https://travis-ci.org/<%= githubUsername %>/<%= moduleName %>)
+# gitignore-cli [![Build Status](https://travis-ci.org/kvasir/gitignore-cli.svg?branch=master)](https://travis-ci.org/kvasir/gitignore-cli)
 
 >
-
 
 ## Install
 
 ```
-$ npm install --save <%= moduleName %>
+$ npm install --save gitignore-cli
 ```
 
 
 ## Usage
 
 ```js
-const <%= camelModuleName %> = require('<%= moduleName %>');
+const <%= camelModuleName %> = require('gitignore-cli');
 
-<%= camelModuleName %>('unicorns');
-//=> 'unicorns & rainbows'
-```
 
 
 ## API
 
-### <%= camelModuleName %>(input, [options])
+### gitignore-cli(input, [options])
 
 #### input
 
@@ -43,26 +39,26 @@ Lorem ipsum.
 ## CLI
 
 ```
-$ npm install --global <%= moduleName %>
+$ npm install --global gitignore-cli
 ```
 
 ```
-$ <%= moduleName %> --help
+$ gitignore-cli --help
 
   Usage
-    <%= moduleName %> [input]
+    gitignore-cli [input]
 
   Options
     --foo  Lorem ipsum. [Default: false]
 
   Examples
-    $ <%= moduleName %>
+    $ gitignore-cli
     unicorns & rainbows
-    $ <%= moduleName %> ponies
+    $ gitignore-cli ponies
     ponies & rainbows
 ```
 
 
 ## License
 
-MIT © [<%= name %>](https://github.com/<%= githubUsername %>)
+MIT © [<%= name %>](https://github.com/kvasir/gitignore-cli)


### PR DESCRIPTION
Renaming the original boilerplate the the name gitignore-cli.
